### PR TITLE
Fix support of ansi escape characters in character string

### DIFF
--- a/test.js
+++ b/test.js
@@ -18,6 +18,22 @@ test('key decoder, plain character', (t) => {
     .write('a')
 })
 
+test('key decoder, numeric character', (t) => {
+  t.plan(4)
+
+  const stream = new PassThrough()
+
+  stream
+    .pipe(new KeyDecoder())
+    .on('data', (key) => {
+      t.is(key.name, '1')
+      t.absent(key.ctrl)
+      t.absent(key.meta)
+      t.absent(key.shift)
+    })
+    .write('1')
+})
+
 test('key decoder, ctrl + c', (t) => {
   t.plan(4)
 
@@ -32,4 +48,40 @@ test('key decoder, ctrl + c', (t) => {
       t.absent(key.shift)
     })
     .write('\x03')
+})
+
+test('key decoder, linefeed', (t) => {
+  t.plan(4)
+
+  const stream = new PassThrough()
+
+  stream
+    .pipe(new KeyDecoder())
+    .on('data', (key) => {
+      t.is(key.name, 'linefeed')
+      t.absent(key.ctrl)
+      t.absent(key.meta)
+      t.absent(key.shift)
+    })
+    .write('\x0a')
+})
+
+test('key decoder, multiple characters', (t) => {
+  t.plan(12)
+
+  const stream = new PassThrough()
+
+  const expectedNames = ['a', 'b', 'linefeed']
+  let expectedNameIndex = 0
+
+  stream
+    .pipe(new KeyDecoder())
+    .on('data', (key) => {
+      t.is(key.name, expectedNames[expectedNameIndex])
+      expectedNameIndex++
+      t.absent(key.ctrl)
+      t.absent(key.meta)
+      t.absent(key.shift)
+    })
+    .write('ab\x0a')
 })

--- a/test.js
+++ b/test.js
@@ -50,6 +50,130 @@ test('key decoder, ctrl + c', (t) => {
     .write('\x03')
 })
 
+test('key decoder, single esc', (t) => {
+  t.plan(4)
+
+  const stream = new PassThrough()
+
+  stream
+    .pipe(new KeyDecoder())
+    .on('data', (key) => {
+      t.is(key.name, 'escape')
+      t.absent(key.ctrl)
+      t.absent(key.meta)
+      t.absent(key.shift)
+    })
+    .write('\x1b')
+})
+
+test('key decoder, double esc', (t) => {
+  t.plan(4)
+
+  const stream = new PassThrough()
+
+  stream
+    .pipe(new KeyDecoder())
+    .on('data', (key) => {
+      t.is(key.name, 'escape')
+      t.absent(key.ctrl)
+      t.ok(key.meta)
+      t.absent(key.shift)
+    })
+    .write('\x1b\x1b')
+})
+
+test('key decoder, meta alphanumeric lowercase', (t) => {
+  t.plan(4)
+
+  const stream = new PassThrough()
+
+  stream
+    .pipe(new KeyDecoder())
+    .on('data', (key) => {
+      t.is(key.name, 'b')
+      t.absent(key.ctrl)
+      t.ok(key.meta)
+      t.absent(key.shift)
+    })
+    .write('\x1bb')
+})
+
+test('key decoder, meta alphanumeric uppercase', (t) => {
+  t.plan(4)
+
+  const stream = new PassThrough()
+
+  stream
+    .pipe(new KeyDecoder())
+    .on('data', (key) => {
+      t.is(key.name, 'f')
+      t.absent(key.ctrl)
+      t.ok(key.meta)
+      t.ok(key.shift)
+    })
+    .write('\x1bF')
+})
+
+test('key decoder, backspace', (t) => {
+  t.plan(16)
+
+  const stream = new PassThrough()
+
+  stream
+    .pipe(new KeyDecoder())
+    .on('data', (key) => {
+      t.is(key.name, 'backspace')
+      t.absent(key.ctrl)
+      t.absent(key.meta)
+      t.absent(key.shift)
+    })
+  stream.write('\b')
+  stream.write('\x7f')
+
+  // With meta prefix
+  const streamMeta = new PassThrough()
+
+  streamMeta
+    .pipe(new KeyDecoder())
+    .on('data', (key) => {
+      t.is(key.name, 'backspace')
+      t.absent(key.ctrl)
+      t.ok(key.meta)
+      t.absent(key.shift)
+    })
+  streamMeta.write('\x1b\b')
+  streamMeta.write('\x1b\x7f')
+})
+
+test('key decoder, space', (t) => {
+  t.plan(8)
+
+  const stream = new PassThrough()
+
+  stream
+    .pipe(new KeyDecoder())
+    .on('data', (key) => {
+      t.is(key.name, 'space')
+      t.absent(key.ctrl)
+      t.absent(key.meta)
+      t.absent(key.shift)
+    })
+    .write(' ')
+
+  // With meta prefix
+  const streamMeta = new PassThrough()
+
+  streamMeta
+    .pipe(new KeyDecoder())
+    .on('data', (key) => {
+      t.is(key.name, 'space')
+      t.absent(key.ctrl)
+      t.ok(key.meta)
+      t.absent(key.shift)
+    })
+    .write('\x1b ')
+})
+
 test('key decoder, linefeed', (t) => {
   t.plan(4)
 
@@ -84,4 +208,24 @@ test('key decoder, multiple characters', (t) => {
       t.absent(key.shift)
     })
     .write('ab\x0a')
+})
+
+test('key decoder, esc before non escapable char is emitted & doesnt carry', (t) => {
+  t.plan(12)
+
+  const stream = new PassThrough()
+
+  const expectedNames = ['escape', 'tab', 'escape']
+  let expectedNameIndex = 0
+
+  stream
+    .pipe(new KeyDecoder())
+    .on('data', (key) => {
+      t.is(key.name, expectedNames[expectedNameIndex])
+      expectedNameIndex++
+      t.absent(key.ctrl, key.name + ' ctrl')
+      t.absent(key.meta, key.name + ' meta')
+      t.absent(key.shift, key.name + ' shift')
+    })
+    .write('\x1b\t\x1b')
 })


### PR DESCRIPTION
This is a proposition for adding support for ansi escape sequences in a character string prompted by the following code using `bare-readline` & `bare-stream` via import maps for easy nodejs comparison testing:
```js
import readline from 'readline'
import { PassThrough } from 'stream'

const input = new PassThrough()
const rl = readline.createInterface({ input })

rl.on('line', (line) => {
  console.log('line', Buffer.from(line))
})

input.write('beep1')
input.write('\r')

input.write('beep2\r')
```

Bare returns: `line <Buffer 62 65 65 70 31>`, but node returns:
```
line <Buffer 62 65 65 70 31>
line <Buffer 62 65 65 70 32>
```

The issue seems to originated in `bare-ansi-escapes` where character strings are parsed differently than individual characters. The following code illustrates this:
```js
const input = new PassThrough()
input.pipe(new KeyDecoder())
  .on('data', (key) => {
    console.log('key', key)
  })
input.write('test1')
input.write('\n')
input.write('test2\n')
```
outputs the following:
```
key Key { name: 't', ctrl: false, meta: false, shift: false }
key Key { name: 'e', ctrl: false, meta: false, shift: false }
key Key { name: 's', ctrl: false, meta: false, shift: false }
key Key { name: 't', ctrl: false, meta: false, shift: false }
key Key { name: '1', ctrl: false, meta: false, shift: false }
key Key { name: 'linefeed', ctrl: false, meta: false, shift: false }
key Key { name: 't', ctrl: false, meta: false, shift: false }
key Key { name: 'e', ctrl: false, meta: false, shift: false }
key Key { name: 's', ctrl: false, meta: false, shift: false }
key Key { name: 't', ctrl: false, meta: false, shift: false }
key Key { name: '2', ctrl: false, meta: false, shift: false }
key Key { name: '\n', ctrl: false, meta: false, shift: false }
```

Note that the `\n` isn't processed when written with other characters.

To this end and given the escape sequences are parsed in this module, I assumed `bare-ansi-escape` should support parsing escape sequences among other characters and eventually landed on parsing one character at a time in the chunk. I didn't do this for the function key sequences given that would be much more complicated than the rest and wanted to make sure I wasn't wasting time. So function keys are checked first and then the rest is parsed one character at a time, meaning function keys are not parsed when included in a character string with other characters yet.

Finally I wrote tests to vet both the new feature and to help ensure that parsing mostly matched the existing implementation. Not all cases are covered but many more are at least. All tests except the escape sequences with other characters pass on the main branch for me.