### PR TITLE
Failing tests for nonalphanumeric characters

### DIFF
--- a/key-decoder.js
+++ b/key-decoder.js
@@ -289,7 +289,7 @@ function * parseKeys (stream) {
     const sequence = s
 
     if (s.length > 0 && (name !== null || escaped || charLengthAt(s, 0) === s.length)) {
-      stream.push(new Key(name, sequence, ctrl, meta, shift))
+      stream.push(new Key(name ?? sequence, sequence, ctrl, meta, shift))
     }
   }
 }

--- a/test.js
+++ b/test.js
@@ -34,6 +34,62 @@ test('key decoder, numeric character', (t) => {
     .write('1')
 })
 
+test('key decoder, non-alphanumeric', (t) => {
+  t.plan(20)
+
+  const stream = new PassThrough()
+
+  const expected = ['-', ';', '$', '^', '[']
+
+  let i = 0
+
+  stream
+    .pipe(new KeyDecoder())
+    .on('data', (key) => {
+      t.is(key.name, expected[i++])
+      t.absent(key.ctrl)
+      t.absent(key.meta)
+      t.absent(key.shift)
+    })
+    .write('-;$^[')
+})
+
+test('key decoder, diaeresis', (t) => {
+  t.plan(4)
+
+  const stream = new PassThrough()
+
+  const expected = ['ë']
+
+  let i = 0
+
+  stream
+    .pipe(new KeyDecoder())
+    .on('data', (key) => {
+      t.is(key.name, expected[i++])
+      t.absent(key.ctrl)
+      t.absent(key.meta)
+      t.absent(key.shift)
+    })
+    .write('\u00eb')
+})
+
+test('key decoder, 1 wide emoji', (t) => {
+  t.plan(4)
+
+  const stream = new PassThrough()
+
+  stream
+    .pipe(new KeyDecoder())
+    .on('data', (key) => {
+      t.is(key.name, '🍐')
+      t.absent(key.ctrl)
+      t.absent(key.meta)
+      t.absent(key.shift)
+    })
+    .write('🍐')
+})
+
 test('key decoder, ctrl + c', (t) => {
   t.plan(4)
 


### PR DESCRIPTION
This PR is primarily for the tests which are not exhaustive, but are just examples of types of characters that currently fail. I also included a fix that lets all escaped or single character sequences without a name through. Feel free to adjust / remove this fix if it doesn't make sense. I can't find the nodejs implementation to compare with to know the correct parsing solution.